### PR TITLE
Adding missing dependency (ng2-device-detector)

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -8,7 +8,7 @@ import { HttpModule } from '@angular/http';
 import { AppRoutingModule } from './app-routing.module';
 
 /* Third-Party */
-import { Ng2DeviceDetector } from 'ng2-device-detector';
+import { Ng2DeviceDetectorModule } from 'ng2-device-detector';
 import {
     AccordionModule,
     ButtonModule,
@@ -67,7 +67,7 @@ import { SettingsService } from './services/settings.service';
         FormsModule,
         HttpModule,
         /* Device Detector */
-        Ng2DeviceDetector,
+        Ng2DeviceDetectorModule.forRoot(),
         /* PrimeNG */
         AccordionModule,
         ButtonModule,

--- a/app/components/resource.component.ts
+++ b/app/components/resource.component.ts
@@ -13,7 +13,7 @@ import {
 }
 from 'angular2-threatconnect/main';
 
-import { Device } from 'ng2-device-detector';
+import { Ng2DeviceService } from 'ng2-device-detector';
 
 
 @Component({
@@ -26,7 +26,7 @@ export class ResourceComponent implements OnInit {
 
     constructor(
         private logging: SpacesLoggingService,
-        private device: Device,
+        private device: Ng2DeviceService,
         private messages: SpacesMessagesService,
         private tcGroup: TcGroupService,
         private tcIndicator: TcIndicatorService

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "angular2-threatconnect-src": "git+https://github.com/ThreatConnect-Inc/angular2-threatconnect.git#master",
+    "ng2-device-detector": "^1.0.0",
     "primeng": "2.0.0",
     "primeui": "^4.1.15"
   },


### PR DESCRIPTION
This fixes and error when building:

```
### Fast Compile >>app/shared/indicator.service.ts
### Fast Compile >>app/shared/nv_pair.ts
Using tsc v2.1.5
app/app.module.ts(11,35): error TS2307: Cannot find module 'ng2-device-detector'.
app/components/resource.component.ts(16,24): error TS2307: Cannot find module 'ng2-device-detector'.
```